### PR TITLE
Fix for Chrome Autoplay

### DIFF
--- a/morse/morse.js
+++ b/morse/morse.js
@@ -10,6 +10,10 @@ window.addEventListener('touchend', stoptone);
 
 function starttone() {
   gainNode.connect(audioCtx.destination);
+  
+  audioCtx.resume().then(() => { //https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio
+    console.log('Playback resumed successfully');
+  });
 }
 
 function stoptone() {


### PR DESCRIPTION
Chrome autoplay requires that you resume playback after some user input.

See: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio